### PR TITLE
NC Cleanup Effort

### DIFF
--- a/overrides/scripts/BlastFurnace.zs
+++ b/overrides/scripts/BlastFurnace.zs
@@ -57,8 +57,8 @@ blast_furnace.findRecipe(120, [<gregtech:meta_item_1:2018>], [<liquid:oxygen> * 
 blast_furnace.findRecipe(120, [<gregtech:meta_item_1:10018>], [<liquid:oxygen> * 1000]).remove();	
 blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:10018>]).fluidInputs([<liquid:oxygen> * 1000]).outputs([<gregtech:meta_item_1:10087>]).property("temperature", 1000).duration(200).EUt(120).buildAndRegister();
 
-//HSLA
-blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:10184>]).fluidInputs([<liquid:oxygen> * 1000]).outputs([<nuclearcraft:alloy:15>]).property("temperature", 1000).duration(200).EUt(120).buildAndRegister();
+//HSLA - unused
+//blast_furnace.recipeBuilder().inputs([<gregtech:meta_item_1:10184>]).fluidInputs([<liquid:oxygen> * 1000]).outputs([<nuclearcraft:alloy:15>]).property("temperature", 1000).duration(200).EUt(120).buildAndRegister();
 
 
 //Kanthal [tier 2]

--- a/overrides/scripts/Earlygame.zs
+++ b/overrides/scripts/Earlygame.zs
@@ -288,8 +288,9 @@ reactor.recipeBuilder().inputs([<contenttweaker:block_dust>]).fluidInputs([<liqu
 reactor.recipeBuilder().inputs([<contenttweaker:block_dust>]).fluidInputs([<liquid:water> * 1000]).outputs(<minecraft:clay>).EUt(15).duration(20).buildAndRegister();
 reactor.recipeBuilder().inputs([<minecraft:magma>]).fluidOutputs(<liquid:lava> * 1000).EUt(30).duration(120).buildAndRegister();
 reactor.recipeBuilder().inputs([<thermalfoundation:fertilizer>]).fluidInputs(<liquid:ammonia> * 100).outputs(<thermalfoundation:fertilizer:1>).EUt(30).duration(120).buildAndRegister();
-reactor.recipeBuilder().inputs([<gregtech:meta_item_1:2039>]).fluidInputs(<liquid:oxygen> * 250).outputs(<nuclearcraft:dust_oxide:2>).EUt(15).duration(120).buildAndRegister();
-reactor.recipeBuilder().inputs([<nuclearcraft:dust_oxide:2>]).fluidInputs(<liquid:phosphoric_acid> * 1000).outputs(<nuclearcraft:dust_oxide:2>).EUt(500).duration(120).buildAndRegister();
+// recipes for Manganese Oxides - currently unused
+// reactor.recipeBuilder().inputs([<gregtech:meta_item_1:2039>]).fluidInputs(<liquid:oxygen> * 250).outputs(<nuclearcraft:dust_oxide:2>).EUt(15).duration(120).buildAndRegister();
+// reactor.recipeBuilder().inputs([<nuclearcraft:dust_oxide:2>]).fluidInputs(<liquid:phosphoric_acid> * 1000).outputs(<nuclearcraft:dust_oxide:2>).EUt(500).duration(120).buildAndRegister();
 mixer.recipeBuilder().inputs([<minecraft:redstone>,<minecraft:glowstone_dust>]).outputs(<nuclearcraft:compound:2> * 2).EUt(22).duration(40).buildAndRegister();
 mixer.recipeBuilder().inputs([<gregtech:meta_item_1:2239>,<gregtech:meta_item_1:2026>]).outputs(<minecraft:glowstone_dust> * 2).EUt(15).duration(80).buildAndRegister();
 mixer.recipeBuilder().inputs([<gregtech:meta_item_1:2033>,<gregtech:meta_item_1:2071>]).outputs(<gregtech:meta_item_1:2189> * 2).EUt(15).duration(40).buildAndRegister();

--- a/overrides/scripts/ExtendedCrafting.zs
+++ b/overrides/scripts/ExtendedCrafting.zs
@@ -340,6 +340,17 @@ fluid_extractor.recipeBuilder()
     .fluidOutputs([<liquid:emerald> * 144])
     .duration(180).EUt(16).buildAndRegister();
 
+// Molten Diamond for NC Active Coolers
+fluid_extractor.recipeBuilder()
+    .inputs([<minecraft:diamond>])
+    .fluidOutputs([<liquid:diamond> * 144])
+    .duration(180).EUt(16).buildAndRegister();
+
+fluid_extractor.recipeBuilder()
+    .inputs([<gregtech:meta_item_1:2111>])
+    .fluidOutputs([<liquid:diamond> * 144])
+    .duration(180).EUt(16).buildAndRegister();
+
 fluid_extractor.recipeBuilder()
     .inputs([<gregtech:meta_item_1:2201>])
     .fluidOutputs([<liquid:quartz> * 144])

--- a/overrides/scripts/JEICleanup.zs
+++ b/overrides/scripts/JEICleanup.zs
@@ -1,14 +1,14 @@
 #priority -9998
 
-import crafttweaker.mods.IMod;
-import crafttweaker.game.IGame;
+import crafttweaker.item.IIngredient;
 import crafttweaker.item.IItemDefinition;
 import crafttweaker.item.IItemStack;
-import crafttweaker.item.IIngredient;
 import crafttweaker.liquid.ILiquidDefinition;
 import crafttweaker.liquid.ILiquidStack;
+import crafttweaker.mods.IMod;
 import crafttweaker.oredict.IOreDict;
 import crafttweaker.oredict.IOreDictEntry;
+
 
 /*
     MetaIDs of SoG's curved plates and double-ingots that aren't gone from JEI
@@ -39,56 +39,6 @@ for meta in curvedPlatesDoubleIngots {
     }
 }
 
-/* Hide as much of NuclearCraft's unused stuff as possible */
-val nc as IMod = loadedMods["nuclearcraft"];
-if(!isNull(nc)) {
-    val ncItems as IItemStack[] = nc.items;
-
-    for item in ncItems {
-        if(item.displayName has " Oxide" |
-           item.displayName has "MOX" |
-           item.displayName has "Molten Salt" |
-           item.displayName has "Eutectic" |
-           item.displayName has "Molten Depleted" |
-           item.displayName has "FLiBe" |
-           item.displayName has "Molten LE" |
-           item.displayName has "Molten HE" |
-           item.displayName has "Fluoride" |
-           item.definition.id has "fluid") {
-            mods.jei.JEI.removeAndHide(item);
-        }
-    }
-
-    /* Hide various unused NC fluids */
-    val containers = [<gregtech:meta_item_1:32405>,
-                      <gregtech:meta_item_1:32762>,
-                      <gregtech:meta_item_1:32406>] as IItemStack[];
-
-    for liquid in game.liquids {
-        if(liquid.displayName has "Eutectic" |
-           liquid.displayName has "Molten Depleted" |
-           liquid.displayName has "Molten LE" |
-           liquid.displayName has "Molten HE" |
-           liquid.displayName has "Fluoride" |
-           liquid.displayName has "FLiBe" |
-           liquid.name has "_23" | 
-           liquid.name has "_24" | 
-           liquid.name has "_25" ) {
-
-            // remove from various GT containers
-            for container in containers {
-                mods.jei.JEI.hide(container.withTag({Fluid: {FluidName: liquid.name, Amount: 1000}}));
-            }
-
-            // Different tag schemas...
-            mods.jei.JEI.hide(<ceramics:clay_bucket>.withTag({fluids: {FluidName: liquid.name, Amount: 1000}}));
-            mods.jei.JEI.hide(<forge:bucketfilled>.withTag({FluidName: liquid.name, Amount: 1000}));
-
-            // Hide the fluid too
-            mods.jei.JEI.hide(liquid*1000);
-        }
-    }
-}
 
 /* Hide all of AE2's facades (can still be crafted, just hiding from JEI) */
 val ae2 as IMod = loadedMods["appliedenergistics2"];

--- a/overrides/scripts/Nuclearcraft.zs
+++ b/overrides/scripts/Nuclearcraft.zs
@@ -81,8 +81,6 @@ val ncItems as IItemStack[] = [
     <nuclearcraft:alloy:14>, // SiC SiC Ceramic Matrix Composite
     <nuclearcraft:alloy:15>, // HSLA Steel
     <nuclearcraft:bin>,
-    <nuclearcraft:block_depleted_thorium>,
-    <nuclearcraft:block_depleted_uranium>,
     <nuclearcraft:boots_hazmat>,
     <nuclearcraft:boron:0>, // all boron isotopes
     <nuclearcraft:boron:1>,
@@ -302,15 +300,23 @@ for fuelObj in fuelObjs {
         mods.jei.JEI.removeAndHide(oxide);
     }
 
-    // Depleted fuels just need to be hidden from JEI
+    // Clean up oxide depleted fuels
     for meta in fuelObj.depletedFuelMetas {
-        var item = itemUtils.getItem(fuelObj.depletedFuelName(), meta);
+        var variant = fuelObj.depletedFuelName();
+        var oxide   = itemUtils.getItem(variant, meta);
+        var regular = itemUtils.getItem(variant, meta - 1);
+
+        // Remove deoxidation smelting recipes
+        furnace.remove(regular, oxide);
 
         // hide from JEI but there's no table recipes
-        mods.jei.JEI.hide(item);
+        mods.jei.JEI.hide(oxide);
 
-        // remove from the fission recipe list
-        mods.nuclearcraft.fission.removeRecipeWithOutput([item]);
+        // remove oxide recipes from the fission reactor recipe list
+        mods.nuclearcraft.fission.removeRecipeWithOutput([oxide]);
+
+        // Remove oxide depleted fuel recipes from the centrifuge
+        centrifuge.findRecipe(24, [oxide], null).remove();
     }
 }
 

--- a/overrides/scripts/Nuclearcraft.zs
+++ b/overrides/scripts/Nuclearcraft.zs
@@ -5,6 +5,7 @@ import crafttweaker.mods.IMod;
 import crafttweaker.oredict.IOreDictEntry;
 import mods.contenttweaker.Fluid;
 import mods.gregtech.recipe.RecipeMap;
+import mods.gregtech.recipe.Recipe;
 
 import scripts.CommonVars.makeShaped as makeShaped;
 
@@ -67,162 +68,181 @@ function purgeFluidFromJEI(fluid as string) {
     mods.jei.JEI.removeAndHide(<forge:bucketfilled>.withTag({FluidName: fluid, Amount: 1000}));
 }
 
-// Nuclearcraft Item Removals
-val ncItems as IItemStack[] = [
-    <nuclearcraft:accelerator_electromagnet_idle>,
-    <nuclearcraft:alloy:3>, // Magnesium Diboride
-    <nuclearcraft:alloy:4>, // Lithium Manganese Dioxide
-    <nuclearcraft:alloy:7>, // Shibuichi Alloy
-    <nuclearcraft:alloy:8>, // Tin Silver Alloy
-    <nuclearcraft:alloy:9>, // Lead Platinum Alloy
-    <nuclearcraft:alloy:11>, // Thermoconducting Alloy
-    <nuclearcraft:alloy:12>, // Zircaloy
-    <nuclearcraft:alloy:13>, // Silicon Carbide
-    <nuclearcraft:alloy:14>, // SiC SiC Ceramic Matrix Composite
-    <nuclearcraft:alloy:15>, // HSLA Steel
-    <nuclearcraft:bin>,
-    <nuclearcraft:boots_hazmat>,
-    <nuclearcraft:boron:0>, // all boron isotopes
-    <nuclearcraft:boron:1>,
-    <nuclearcraft:boron:2>,
-    <nuclearcraft:boron:3>,
-    <nuclearcraft:chest_hazmat>,
-    <nuclearcraft:cocoa_butter>,
-    <nuclearcraft:cocoa_solids>,
-    <nuclearcraft:compound:0>, // Calcium Sulfate
-    <nuclearcraft:compound:1>, // Crystal Binder
-    <nuclearcraft:compound:3>, // Sodium Fluoride
-    <nuclearcraft:compound:4>, // Potassium Fluoride
-    <nuclearcraft:compound:5>, // Sodium Hydroxide
-    <nuclearcraft:compound:6>, // Potassium Hydroxide
-    <nuclearcraft:compound:7>, // Borax
-    <nuclearcraft:compound:8>, // Dimensional Blend
-    <nuclearcraft:compound:9>, // Carbon-Manganese Blend
-    <nuclearcraft:compound:10>, // Alugentum Dust
-    <nuclearcraft:dark_chocolate>,
-    <nuclearcraft:decay_generator>,
-    <nuclearcraft:dry_earth>,
-    <nuclearcraft:dust:10>, // Zirconium Dust
-    <nuclearcraft:dust_oxide>,   // Thorium Oxide Dust
-    <nuclearcraft:dust_oxide:1>, // Uranium Oxide Dust
-    <nuclearcraft:dust_oxide:2>, // Manganese Oxide Dust
-    <nuclearcraft:dust_oxide:3>, // Manganese Dioxide Dust
-    <nuclearcraft:electromagnet_supercooler_idle>,
-    <nuclearcraft:fission_controller_idle>,
-    <nuclearcraft:flour>,
-    <nuclearcraft:fusion_connector>,
-    <nuclearcraft:fusion_core>,
-    <nuclearcraft:fusion_electromagnet_idle>,
-    <nuclearcraft:fusion_electromagnet_transparent_idle>,
-    <nuclearcraft:geiger_counter>,
-    <nuclearcraft:gelatin>,
-    <nuclearcraft:gem:0>, // all NC gems
-    <nuclearcraft:gem:1>,
-    <nuclearcraft:gem:2>,
-    <nuclearcraft:gem:3>,
-    <nuclearcraft:gem:4>,
-    <nuclearcraft:gem:5>,
-    <nuclearcraft:gem:6>,
-    <nuclearcraft:gem_dust:4>, // Hexagonal Boron Nitride
-    <nuclearcraft:gem_dust:5>, // Crushed Fluorite
-    <nuclearcraft:gem_dust:6>, // Sulfur
-    <nuclearcraft:gem_dust:8>, // Crushed Villiaumite
-    <nuclearcraft:gem_dust:9>, // Crushed Carobbiite
-    <nuclearcraft:gem_dust:10>,// Crushed Arsenic
-    <nuclearcraft:gem_dust:11>,// Crushed End Stone
-    <nuclearcraft:graham_cracker>,
-    <nuclearcraft:ground_cocoa_nibs>,
-    <nuclearcraft:heat_exchanger_condenser_tube_copper>,
-    <nuclearcraft:heat_exchanger_condenser_tube_hard_carbon>,
-    <nuclearcraft:heat_exchanger_condenser_tube_thermoconducting>,
-    <nuclearcraft:heat_exchanger_controller>,
-    <nuclearcraft:heat_exchanger_frame>,
-    <nuclearcraft:heat_exchanger_glass>,
-    <nuclearcraft:heat_exchanger_tube_copper>,
-    <nuclearcraft:heat_exchanger_tube_hard_carbon>,
-    <nuclearcraft:heat_exchanger_tube_thermoconducting>,
-    <nuclearcraft:heat_exchanger_vent>,
-    <nuclearcraft:heat_exchanger_wall>,
-    <nuclearcraft:helm_hazmat>,
-    <nuclearcraft:ingot:10>,       // Zirconium Ingot
-    <nuclearcraft:ingot_block:10>, // Zirconium Block
-    <nuclearcraft:ingot_oxide>,    // Thorium Oxide Ingot
-    <nuclearcraft:ingot_oxide:1>,  // Uranium Oxide Ingot
-    <nuclearcraft:ingot_oxide:2>,  // Manganese Oxide Ingot
-    <nuclearcraft:ingot_oxide:3>,  // Manganese Dioxide Ingot
-    <nuclearcraft:legs_hazmat>,
-    <nuclearcraft:lithium:0>, // all lithium isotopes
-    <nuclearcraft:lithium:1>,
-    <nuclearcraft:lithium:2>,
-    <nuclearcraft:lithium:3>,
-    <nuclearcraft:lithium_ion_battery_advanced>,
-    <nuclearcraft:lithium_ion_battery_basic>,
-    <nuclearcraft:lithium_ion_battery_du>,
-    <nuclearcraft:lithium_ion_battery_elite>,
-    <nuclearcraft:lithium_ion_cell>,
-    <nuclearcraft:marshmallow>,
-    <nuclearcraft:milk_chocolate>,
-    <nuclearcraft:moresmore>,
-    <nuclearcraft:part:5>,  // Magnesium Diboride Solenoid
-    <nuclearcraft:part:6>,  // Bioplastic
-    <nuclearcraft:part:11>, // Empty Frame
-    <nuclearcraft:part:13>, // Silicon Carbide Fiber
-    <nuclearcraft:portable_ender_chest>,
-    <nuclearcraft:radiation_scrubber>,
-    <nuclearcraft:radaway_slow>,
-    <nuclearcraft:rad_shielding:0>, // Light Rad Shielding
-    <nuclearcraft:rad_shielding:1>, // Medium Rad Shielding
-    <nuclearcraft:rad_shielding:2>, // Heavy Rad Shielding
-    <nuclearcraft:rad_x>,
-    <nuclearcraft:roasted_cocoa_beans>,
-    <nuclearcraft:salt_fission_beam>,
-    <nuclearcraft:salt_fission_computer_port>,
-    <nuclearcraft:salt_fission_distributor>,
-    <nuclearcraft:salt_fission_frame>,
-    <nuclearcraft:salt_fission_glass>,
-    <nuclearcraft:salt_fission_heater>,
-    <nuclearcraft:salt_fission_moderator>,
-    <nuclearcraft:salt_fission_redstone_port>,
-    <nuclearcraft:salt_fission_retriever>,
-    <nuclearcraft:salt_fission_vent>,
-    <nuclearcraft:salt_fission_vessel>,
-    <nuclearcraft:salt_fission_wall>,
-    <nuclearcraft:smore>,
-    <nuclearcraft:solar_panel_advanced>,
-    <nuclearcraft:solar_panel_basic>,
-    <nuclearcraft:solar_panel_du>,
-    <nuclearcraft:solar_panel_elite>,
-    <nuclearcraft:tiny_dust_lead>,
-    <nuclearcraft:turbine_controller>,
-    <nuclearcraft:turbine_dynamo_coil:0>,
-    <nuclearcraft:turbine_dynamo_coil:1>,
-    <nuclearcraft:turbine_dynamo_coil:2>,
-    <nuclearcraft:turbine_dynamo_coil:3>,
-    <nuclearcraft:turbine_dynamo_coil:4>,
-    <nuclearcraft:turbine_dynamo_coil:5>,
-    <nuclearcraft:turbine_frame>,
-    <nuclearcraft:turbine_glass>,
-    <nuclearcraft:turbine_inlet>,
-    <nuclearcraft:turbine_outlet>,
-    <nuclearcraft:turbine_rotor_bearing>,
-    <nuclearcraft:turbine_rotor_blade_extreme>,
-    <nuclearcraft:turbine_rotor_blade_sic_sic_cmc>,
-    <nuclearcraft:turbine_rotor_blade_steel>,
-    <nuclearcraft:turbine_rotor_shaft>,
-    <nuclearcraft:turbine_rotor_stator>,
-    <nuclearcraft:turbine_wall>,
-    <nuclearcraft:unsweetened_chocolate>,
-    <nuclearcraft:upgrade:0>, // Speed Upgrade (NC Machines)
-    <nuclearcraft:upgrade:1>, // Energy Upgrade (NC Machines)
-    <nuclearcraft:voltaic_pile_advanced>,
-    <nuclearcraft:voltaic_pile_basic>,
-    <nuclearcraft:voltaic_pile_du>,
-    <nuclearcraft:voltaic_pile_elite>,
-] as IItemStack[];
+zenClass Removal {
 
-for ncItem in ncItems {
-    furnace.remove(ncItem);
-    mods.jei.JEI.removeAndHide(ncItem);
+    var item as IItemStack;
+    var hasFurnace as bool = false;
+
+    zenConstructor(item as IItemStack) {
+        this.item = item;
+    }
+
+    zenConstructor(item as IItemStack, hasFurnace as bool) {
+        this.item = item;
+        this.hasFurnace = hasFurnace;
+    }
+
+}
+
+
+// Nuclearcraft Item Removals
+val removals as Removal[] = [
+    Removal(<nuclearcraft:accelerator_electromagnet_idle>),
+    Removal(<nuclearcraft:alloy:3>), // Magnesium Diboride
+    Removal(<nuclearcraft:alloy:4>), // Lithium Manganese Dioxide
+    Removal(<nuclearcraft:alloy:7>), // Shibuichi Alloy
+    Removal(<nuclearcraft:alloy:8>), // Tin Silver Alloy
+    Removal(<nuclearcraft:alloy:9>), // Lead Platinum Alloy
+    Removal(<nuclearcraft:alloy:11>), // Thermoconducting Alloy
+    Removal(<nuclearcraft:alloy:12>), // Zircaloy
+    Removal(<nuclearcraft:alloy:13>), // Silicon Carbide
+    Removal(<nuclearcraft:alloy:14>), // SiC SiC Ceramic Matrix Composite
+    Removal(<nuclearcraft:alloy:15>), // HSLA Steel
+    Removal(<nuclearcraft:bin>),
+    Removal(<nuclearcraft:boots_hazmat>),
+    Removal(<nuclearcraft:boron:0>), // all boron isotopes
+    Removal(<nuclearcraft:boron:1>),
+    Removal(<nuclearcraft:boron:2>),
+    Removal(<nuclearcraft:boron:3>),
+    Removal(<nuclearcraft:chest_hazmat>),
+    Removal(<nuclearcraft:cocoa_butter>),
+    Removal(<nuclearcraft:cocoa_solids>),
+    Removal(<nuclearcraft:compound:0>), // Calcium Sulfate
+    Removal(<nuclearcraft:compound:1>), // Crystal Binder
+    Removal(<nuclearcraft:compound:3>), // Sodium Fluoride
+    Removal(<nuclearcraft:compound:4>), // Potassium Fluoride
+    Removal(<nuclearcraft:compound:5>), // Sodium Hydroxide
+    Removal(<nuclearcraft:compound:6>), // Potassium Hydroxide
+    Removal(<nuclearcraft:compound:7>), // Borax
+    Removal(<nuclearcraft:compound:8>), // Dimensional Blend
+    Removal(<nuclearcraft:compound:9>), // Carbon-Manganese Blend
+    Removal(<nuclearcraft:compound:10>), // Alugentum Dust
+    Removal(<nuclearcraft:dark_chocolate>),
+    Removal(<nuclearcraft:decay_generator>),
+    Removal(<nuclearcraft:dry_earth>),
+    Removal(<nuclearcraft:dust:10>), // Zirconium Dust
+    Removal(<nuclearcraft:dust_oxide>),   // Thorium Oxide Dust
+    Removal(<nuclearcraft:dust_oxide:1>), // Uranium Oxide Dust
+    Removal(<nuclearcraft:dust_oxide:2>, true), // Manganese Oxide Dust
+    Removal(<nuclearcraft:dust_oxide:3>), // Manganese Dioxide Dust
+    Removal(<nuclearcraft:electromagnet_supercooler_idle>),
+    Removal(<nuclearcraft:fission_controller_idle>),
+    Removal(<nuclearcraft:flour>),
+    Removal(<nuclearcraft:fusion_connector>),
+    Removal(<nuclearcraft:fusion_core>),
+    Removal(<nuclearcraft:fusion_electromagnet_idle>),
+    Removal(<nuclearcraft:fusion_electromagnet_transparent_idle>),
+    Removal(<nuclearcraft:geiger_counter>),
+    Removal(<nuclearcraft:gelatin>),
+    Removal(<nuclearcraft:gem:0>), // all NC gems
+    Removal(<nuclearcraft:gem:1>),
+    Removal(<nuclearcraft:gem:2>),
+    Removal(<nuclearcraft:gem:3>),
+    Removal(<nuclearcraft:gem:4>),
+    Removal(<nuclearcraft:gem:5>),
+    Removal(<nuclearcraft:gem:6>),
+    Removal(<nuclearcraft:gem_dust:4>), // Hexagonal Boron Nitride
+    Removal(<nuclearcraft:gem_dust:5>), // Crushed Fluorite
+    Removal(<nuclearcraft:gem_dust:6>), // Sulfur
+    Removal(<nuclearcraft:gem_dust:8>), // Crushed Villiaumite
+    Removal(<nuclearcraft:gem_dust:9>), // Crushed Carobbiite
+    Removal(<nuclearcraft:gem_dust:10>),// Crushed Arsenic
+    Removal(<nuclearcraft:gem_dust:11>),// Crushed End Stone
+    Removal(<nuclearcraft:graham_cracker>),
+    Removal(<nuclearcraft:ground_cocoa_nibs>),
+    Removal(<nuclearcraft:heat_exchanger_condenser_tube_copper>),
+    Removal(<nuclearcraft:heat_exchanger_condenser_tube_hard_carbon>),
+    Removal(<nuclearcraft:heat_exchanger_condenser_tube_thermoconducting>),
+    Removal(<nuclearcraft:heat_exchanger_controller>),
+    Removal(<nuclearcraft:heat_exchanger_frame>),
+    Removal(<nuclearcraft:heat_exchanger_glass>),
+    Removal(<nuclearcraft:heat_exchanger_tube_copper>),
+    Removal(<nuclearcraft:heat_exchanger_tube_hard_carbon>),
+    Removal(<nuclearcraft:heat_exchanger_tube_thermoconducting>),
+    Removal(<nuclearcraft:heat_exchanger_vent>),
+    Removal(<nuclearcraft:heat_exchanger_wall>),
+    Removal(<nuclearcraft:helm_hazmat>),
+    Removal(<nuclearcraft:ingot:10>, true), // Zirconium Ingot
+    Removal(<nuclearcraft:ingot_block:10>), // Zirconium Block
+    Removal(<nuclearcraft:ingot_oxide>, true),    // Thorium Oxide Ingot
+    Removal(<nuclearcraft:ingot_oxide:1>, true),  // Uranium Oxide Ingot
+    Removal(<nuclearcraft:ingot_oxide:2>, true),  // Manganese Oxide Ingot
+    Removal(<nuclearcraft:ingot_oxide:3>, true),  // Manganese Dioxide Ingot
+    Removal(<nuclearcraft:legs_hazmat>),
+    Removal(<nuclearcraft:lithium:0>), // all lithium isotopes
+    Removal(<nuclearcraft:lithium:1>),
+    Removal(<nuclearcraft:lithium:2>),
+    Removal(<nuclearcraft:lithium:3>),
+    Removal(<nuclearcraft:lithium_ion_battery_advanced>),
+    Removal(<nuclearcraft:lithium_ion_battery_basic>),
+    Removal(<nuclearcraft:lithium_ion_battery_du>),
+    Removal(<nuclearcraft:lithium_ion_battery_elite>),
+    Removal(<nuclearcraft:lithium_ion_cell>),
+    Removal(<nuclearcraft:marshmallow>),
+    Removal(<nuclearcraft:milk_chocolate>),
+    Removal(<nuclearcraft:moresmore>),
+    Removal(<nuclearcraft:part:5>),  // Magnesium Diboride Solenoid
+    Removal(<nuclearcraft:part:6>),  // Bioplastic
+    Removal(<nuclearcraft:part:11>), // Empty Frame
+    Removal(<nuclearcraft:part:13>), // Silicon Carbide Fiber
+    Removal(<nuclearcraft:portable_ender_chest>),
+    Removal(<nuclearcraft:radiation_scrubber>),
+    Removal(<nuclearcraft:radaway_slow>),
+    Removal(<nuclearcraft:rad_shielding:0>), // Light Rad Shielding
+    Removal(<nuclearcraft:rad_shielding:1>), // Medium Rad Shielding
+    Removal(<nuclearcraft:rad_shielding:2>), // Heavy Rad Shielding
+    Removal(<nuclearcraft:rad_x>),
+    Removal(<nuclearcraft:roasted_cocoa_beans>, true),
+    Removal(<nuclearcraft:salt_fission_beam>),
+    Removal(<nuclearcraft:salt_fission_computer_port>),
+    Removal(<nuclearcraft:salt_fission_distributor>),
+    Removal(<nuclearcraft:salt_fission_frame>),
+    Removal(<nuclearcraft:salt_fission_glass>),
+    Removal(<nuclearcraft:salt_fission_heater>),
+    Removal(<nuclearcraft:salt_fission_moderator>),
+    Removal(<nuclearcraft:salt_fission_redstone_port>),
+    Removal(<nuclearcraft:salt_fission_retriever>),
+    Removal(<nuclearcraft:salt_fission_vent>),
+    Removal(<nuclearcraft:salt_fission_vessel>),
+    Removal(<nuclearcraft:salt_fission_wall>),
+    Removal(<nuclearcraft:smore>),
+    Removal(<nuclearcraft:solar_panel_advanced>),
+    Removal(<nuclearcraft:solar_panel_basic>),
+    Removal(<nuclearcraft:solar_panel_du>),
+    Removal(<nuclearcraft:solar_panel_elite>),
+    Removal(<nuclearcraft:tiny_dust_lead>),
+    Removal(<nuclearcraft:turbine_controller>),
+    Removal(<nuclearcraft:turbine_dynamo_coil:0>),
+    Removal(<nuclearcraft:turbine_dynamo_coil:1>),
+    Removal(<nuclearcraft:turbine_dynamo_coil:2>),
+    Removal(<nuclearcraft:turbine_dynamo_coil:3>),
+    Removal(<nuclearcraft:turbine_dynamo_coil:4>),
+    Removal(<nuclearcraft:turbine_dynamo_coil:5>),
+    Removal(<nuclearcraft:turbine_frame>),
+    Removal(<nuclearcraft:turbine_glass>),
+    Removal(<nuclearcraft:turbine_inlet>),
+    Removal(<nuclearcraft:turbine_outlet>),
+    Removal(<nuclearcraft:turbine_rotor_bearing>),
+    Removal(<nuclearcraft:turbine_rotor_blade_extreme>),
+    Removal(<nuclearcraft:turbine_rotor_blade_sic_sic_cmc>),
+    Removal(<nuclearcraft:turbine_rotor_blade_steel>),
+    Removal(<nuclearcraft:turbine_rotor_shaft>),
+    Removal(<nuclearcraft:turbine_rotor_stator>),
+    Removal(<nuclearcraft:turbine_wall>),
+    Removal(<nuclearcraft:unsweetened_chocolate>),
+    Removal(<nuclearcraft:upgrade:0>), // Speed Upgrade (NC Machines)
+    Removal(<nuclearcraft:upgrade:1>), // Energy Upgrade (NC Machines)
+    Removal(<nuclearcraft:voltaic_pile_advanced>),
+    Removal(<nuclearcraft:voltaic_pile_basic>),
+    Removal(<nuclearcraft:voltaic_pile_du>),
+    Removal(<nuclearcraft:voltaic_pile_elite>),
+] as Removal[];
+
+for removal in removals {
+    if(removal.hasFurnace) {
+        furnace.remove(removal.item);
+    }
+    mods.jei.JEI.removeAndHide(removal.item);
 }
 
 zenClass Material {
@@ -254,6 +274,19 @@ zenClass Material {
     function depletedFuelName() as string {
         return "nuclearcraft:depleted_fuel_" + this.name;
     }
+
+    function fissileItem(meta as int) as IItemStack {
+        return itemUtils.getItem(this.fissileName(), meta);
+    }
+
+    function fuelItem(meta as int) as IItemStack {
+        return itemUtils.getItem(this.fuelName(), meta);
+    }
+
+    function depletedFuelItem(meta as int) as IItemStack {
+        return itemUtils.getItem(this.depletedFuelName(), meta);
+    }
+
 }
 
 // oxides are odd-valued metadata values beginning with 1.
@@ -273,9 +306,8 @@ var fuelObjs as Material[] = [
 for fuelObj in fuelObjs {
     // Clean up oxide fissiles
     for meta in fuelObj.fissileMetas {
-        var variant = fuelObj.fissileName();
-        var oxide   = itemUtils.getItem(variant, meta);
-        var regular = itemUtils.getItem(variant, meta - 1);
+        var oxide   = fuelObj.fissileItem(meta);
+        var regular = fuelObj.fissileItem(meta - 1);
 
         // remove de-oxidation smelting?
         furnace.remove(regular, oxide);
@@ -286,9 +318,8 @@ for fuelObj in fuelObjs {
 
     // Clean up oxide fissile fuels
     for meta in fuelObj.fuelMetas {
-        var variant = fuelObj.fuelName();
-        var oxide   = itemUtils.getItem(variant, meta);
-        var regular = itemUtils.getItem(variant, meta - 1);
+        var oxide   = fuelObj.fuelItem(meta);
+        var regular = fuelObj.fuelItem(meta - 1);
 
         // Remove deoxidation smelting recipes
         furnace.remove(regular, oxide);
@@ -302,9 +333,8 @@ for fuelObj in fuelObjs {
 
     // Clean up oxide depleted fuels
     for meta in fuelObj.depletedFuelMetas {
-        var variant = fuelObj.depletedFuelName();
-        var oxide   = itemUtils.getItem(variant, meta);
-        var regular = itemUtils.getItem(variant, meta - 1);
+        var oxide   = fuelObj.depletedFuelItem(meta);
+        var regular = fuelObj.depletedFuelItem(meta - 1);
 
         // Remove deoxidation smelting recipes
         furnace.remove(regular, oxide);
@@ -316,7 +346,11 @@ for fuelObj in fuelObjs {
         mods.nuclearcraft.fission.removeRecipeWithOutput([oxide]);
 
         // Remove oxide depleted fuel recipes from the centrifuge
-        centrifuge.findRecipe(24, [oxide], null).remove();
+        // One of the ic2 ones threw a null here.
+        val cr as Recipe = centrifuge.findRecipe(24, [oxide], null);
+        if(!isNull(cr)) {
+            cr.remove();
+        }
     }
 }
 

--- a/overrides/scripts/Nuclearcraft.zs
+++ b/overrides/scripts/Nuclearcraft.zs
@@ -1,24 +1,18 @@
-import crafttweaker.item.IItemStack;
+import crafttweaker.game.IGame;
 import crafttweaker.item.IIngredient;
+import crafttweaker.item.IItemStack;
+import crafttweaker.mods.IMod;
 import crafttweaker.oredict.IOreDictEntry;
 import mods.contenttweaker.Fluid;
-
 import mods.gregtech.recipe.RecipeMap;
 
-/*
-[[<>, <>, <>, <>, <>, <>],
-[<>, <>, <>, <>, <>, <>],
-[<>, <>, <>, <>, <>, <>],
-[<>, <>, <>, <>, <>, <>],
-[<>, <>, <>, <>, <>, <>]]); */
+import scripts.CommonVars.makeShaped as makeShaped;
 
 //////////////////////////////////////////////////////////////
-/////////////       Nuclearcraft       //////////////////
+/////////////////       Nuclearcraft       ///////////////////
 //////////////////////////////////////////////////////////////
 
-recipes.remove(<nuclearcraft:compound:2>);
-mixer.recipeBuilder().inputs([<minecraft:redstone>,<minecraft:glowstone_dust>]).outputs(<nuclearcraft:compound:2> * 2).EUt(22).duration(40).buildAndRegister();
-
+// Remove all recipes from unused NC machine categories
 mods.nuclearcraft.manufactory.removeAllRecipes();
 mods.nuclearcraft.isotope_separator.removeAllRecipes();
 mods.nuclearcraft.decay_hastener.removeAllRecipes();
@@ -41,138 +35,735 @@ mods.nuclearcraft.rock_crusher.removeAllRecipes();
 mods.nuclearcraft.decay_generator.removeAllRecipes();
 mods.nuclearcraft.fusion.removeAllRecipes();
 mods.nuclearcraft.salt_fission.removeAllRecipes();
+mods.nuclearcraft.heat_exchanger.removeAllRecipes();
+//mods.nuclearcraft.steam_turbine.removeAllRecipes(); FIXME: probably in a newer version?
+mods.nuclearcraft.condenser.removeAllRecipes();
+
+// Hide NC categories related to MSR and Turbines
+val jeiCategories as string[] = [
+    "nuclearcraft_collector",
+    "nuclearcraft_heat_exchanger",
+    "nuclearcraft_high_turbine",
+    "nuclearcraft_condenser",
+] as string[];
+
+for jeiCategory in jeiCategories {
+    mods.jei.JEI.hideCategory(jeiCategory);
+}
+
+function purgeFluidFromJEI(fluid as string) {
+    // gtce various metal cells
+    val containers = [<gregtech:meta_item_1:32405>,
+                      <gregtech:meta_item_1:32762>,
+                      <gregtech:meta_item_1:32406>] as IItemStack[];
+
+    // remove from various GT containers
+    for container in containers {
+        mods.jei.JEI.removeAndHide(container.withTag({Fluid: {FluidName: fluid, Amount: 1000}}));
+    }
+
+    // Different tag schemas...
+    mods.jei.JEI.removeAndHide(<ceramics:clay_bucket>.withTag({fluids: {FluidName: fluid, Amount: 1000}}));
+    mods.jei.JEI.removeAndHide(<forge:bucketfilled>.withTag({FluidName: fluid, Amount: 1000}));
+}
+
+// Nuclearcraft Item Removals
+val ncItems as IItemStack[] = [
+    <nuclearcraft:accelerator_electromagnet_idle>,
+    <nuclearcraft:alloy:3>, // Magnesium Diboride
+    <nuclearcraft:alloy:4>, // Lithium Manganese Dioxide
+    <nuclearcraft:alloy:7>, // Shibuichi Alloy
+    <nuclearcraft:alloy:8>, // Tin Silver Alloy
+    <nuclearcraft:alloy:9>, // Lead Platinum Alloy
+    <nuclearcraft:alloy:10>, // Extreme Alloy
+    <nuclearcraft:alloy:11>, // Thermoconducting Alloy
+    <nuclearcraft:alloy:12>, // Zircaloy
+    <nuclearcraft:alloy:13>, // Silicon Carbide
+    <nuclearcraft:alloy:14>, // SiC SiC Ceramic Matrix Composite
+    <nuclearcraft:alloy:15>, // HSLA Steel
+    <nuclearcraft:bin>,
+    <nuclearcraft:block_depleted_thorium>,
+    <nuclearcraft:block_depleted_uranium>,
+    <nuclearcraft:boots_hazmat>,
+    <nuclearcraft:boron:0>, // all boron isotopes
+    <nuclearcraft:boron:1>,
+    <nuclearcraft:boron:2>,
+    <nuclearcraft:boron:3>,
+    <nuclearcraft:chest_hazmat>,
+    <nuclearcraft:cocoa_butter>,
+    <nuclearcraft:cocoa_solids>,
+    <nuclearcraft:compound:0>, // Calcium Sulfate
+    <nuclearcraft:compound:1>, // Crystal Binder
+    <nuclearcraft:compound:3>, // Sodium Fluoride
+    <nuclearcraft:compound:4>, // Potassium Fluoride
+    <nuclearcraft:compound:5>, // Sodium Hydroxide
+    <nuclearcraft:compound:6>, // Potassium Hydroxide
+    <nuclearcraft:compound:7>, // Borax
+    <nuclearcraft:compound:8>, // Dimensional Blend
+    <nuclearcraft:compound:9>, // Carbon-Manganese Blend
+    <nuclearcraft:compound:10>, // Alugentum Dust
+    <nuclearcraft:dark_chocolate>,
+    <nuclearcraft:decay_generator>,
+    <nuclearcraft:depleted_fuel_ic2>,   // Depleted Uranium Nuclear Fuel
+    <nuclearcraft:depleted_fuel_ic2:1>, // Depleted MOX Nuclear Fuel
+    <nuclearcraft:dry_earth>,
+    <nuclearcraft:dust:10>, // Zirconium Dust
+    <nuclearcraft:dust_oxide>,   // Thorium Oxide Dust
+    <nuclearcraft:dust_oxide:1>, // Uranium Oxide Dust
+    <nuclearcraft:dust_oxide:2>, // Manganese Oxide Dust
+    <nuclearcraft:dust_oxide:3>, // Manganese Dioxide Dust
+    <nuclearcraft:electromagnet_supercooler_idle>,
+    <nuclearcraft:fission_controller_idle>,
+    <nuclearcraft:flour>,
+    <nuclearcraft:fusion_connector>,
+    <nuclearcraft:fusion_core>,
+    <nuclearcraft:fusion_electromagnet_idle>,
+    <nuclearcraft:fusion_electromagnet_transparent_idle>,
+    <nuclearcraft:geiger_counter>,
+    <nuclearcraft:gelatin>,
+    <nuclearcraft:gem:0>, // all NC gems
+    <nuclearcraft:gem:1>,
+    <nuclearcraft:gem:2>,
+    <nuclearcraft:gem:3>,
+    <nuclearcraft:gem:4>,
+    <nuclearcraft:gem:5>,
+    <nuclearcraft:gem:6>,
+    <nuclearcraft:gem_dust:4>, // Hexagonal Boron Nitride
+    <nuclearcraft:gem_dust:5>, // Crushed Fluorite
+    <nuclearcraft:gem_dust:6>, // Sulfur
+    <nuclearcraft:gem_dust:8>, // Crushed Villiaumite
+    <nuclearcraft:gem_dust:9>, // Crushed Carobbiite
+    <nuclearcraft:gem_dust:10>,// Crushed Arsenic
+    <nuclearcraft:gem_dust:11>,// Crushed End Stone
+    <nuclearcraft:graham_cracker>,
+    <nuclearcraft:ground_cocoa_nibs>,
+    <nuclearcraft:heat_exchanger_condenser_tube_copper>,
+    <nuclearcraft:heat_exchanger_condenser_tube_hard_carbon>,
+    <nuclearcraft:heat_exchanger_condenser_tube_thermoconducting>,
+    <nuclearcraft:heat_exchanger_controller>,
+    <nuclearcraft:heat_exchanger_frame>,
+    <nuclearcraft:heat_exchanger_glass>,
+    <nuclearcraft:heat_exchanger_tube_copper>,
+    <nuclearcraft:heat_exchanger_tube_hard_carbon>,
+    <nuclearcraft:heat_exchanger_tube_thermoconducting>,
+    <nuclearcraft:heat_exchanger_vent>,
+    <nuclearcraft:heat_exchanger_wall>,
+    <nuclearcraft:helm_hazmat>,
+    <nuclearcraft:ingot:10>,       // Zirconium Ingot
+    <nuclearcraft:ingot_block:10>, // Zirconium Block
+    <nuclearcraft:ingot_oxide>,    // Thorium Oxide Ingot
+    <nuclearcraft:ingot_oxide:1>,  // Uranium Oxide Ingot
+    <nuclearcraft:ingot_oxide:2>,  // Manganese Oxide Ingot
+    <nuclearcraft:ingot_oxide:3>,  // Manganese Dioxide Ingot
+    <nuclearcraft:legs_hazmat>,
+    <nuclearcraft:lithium:0>, // all lithium isotopes
+    <nuclearcraft:lithium:1>,
+    <nuclearcraft:lithium:2>,
+    <nuclearcraft:lithium:3>,
+    <nuclearcraft:lithium_ion_battery_advanced>,
+    <nuclearcraft:lithium_ion_battery_basic>,
+    <nuclearcraft:lithium_ion_battery_du>,
+    <nuclearcraft:lithium_ion_battery_elite>,
+    <nuclearcraft:lithium_ion_cell>,
+    <nuclearcraft:marshmallow>,
+    <nuclearcraft:milk_chocolate>,
+    <nuclearcraft:moresmore>,
+    <nuclearcraft:part:5>,  // Magnesium Diboride Solenoid
+    <nuclearcraft:part:6>,  // Bioplastic
+    <nuclearcraft:part:11>, // Empty Frame
+    <nuclearcraft:part:12>, // Steel Frame
+    <nuclearcraft:part:13>, // Silicon Carbide Fiber
+    <nuclearcraft:portable_ender_chest>,
+    <nuclearcraft:radiation_scrubber>,
+    <nuclearcraft:radaway_slow>,
+    <nuclearcraft:rad_shielding:0>, // Light Rad Shielding
+    <nuclearcraft:rad_shielding:1>, // Medium Rad Shielding
+    <nuclearcraft:rad_shielding:2>, // Heavy Rad Shielding
+    <nuclearcraft:rad_x>,
+    <nuclearcraft:roasted_cocoa_beans>,
+    <nuclearcraft:salt_fission_beam>,
+    <nuclearcraft:salt_fission_computer_port>,
+    <nuclearcraft:salt_fission_controller>,
+    <nuclearcraft:salt_fission_distributor>,
+    <nuclearcraft:salt_fission_frame>,
+    <nuclearcraft:salt_fission_glass>,
+    <nuclearcraft:salt_fission_heater>,
+    <nuclearcraft:salt_fission_moderator>,
+    <nuclearcraft:salt_fission_redstone_port>,
+    <nuclearcraft:salt_fission_retriever>,
+    <nuclearcraft:salt_fission_vent>,
+    <nuclearcraft:salt_fission_vessel>,
+    <nuclearcraft:salt_fission_wall>,
+    <nuclearcraft:smore>,
+    <nuclearcraft:solar_panel_advanced>,
+    <nuclearcraft:solar_panel_basic>,
+    <nuclearcraft:solar_panel_du>,
+    <nuclearcraft:solar_panel_elite>,
+    <nuclearcraft:tiny_dust_lead>,
+    <nuclearcraft:turbine_controller>,
+    <nuclearcraft:turbine_dynamo_coil:0>,
+    <nuclearcraft:turbine_dynamo_coil:1>,
+    <nuclearcraft:turbine_dynamo_coil:2>,
+    <nuclearcraft:turbine_dynamo_coil:3>,
+    <nuclearcraft:turbine_dynamo_coil:4>,
+    <nuclearcraft:turbine_dynamo_coil:5>,
+    <nuclearcraft:turbine_frame>,
+    <nuclearcraft:turbine_glass>,
+    <nuclearcraft:turbine_inlet>,
+    <nuclearcraft:turbine_outlet>,
+    <nuclearcraft:turbine_rotor_bearing>,
+    <nuclearcraft:turbine_rotor_blade_extreme>,
+    <nuclearcraft:turbine_rotor_blade_sic_sic_cmc>,
+    <nuclearcraft:turbine_rotor_blade_steel>,
+    <nuclearcraft:turbine_rotor_shaft>,
+    <nuclearcraft:turbine_rotor_stator>,
+    <nuclearcraft:turbine_wall>,
+    <nuclearcraft:unsweetened_chocolate>,
+    <nuclearcraft:upgrade:0>, // Speed Upgrade (NC Machines)
+    <nuclearcraft:upgrade:1>, // Energy Upgrade (NC Machines)
+    <nuclearcraft:voltaic_pile_advanced>,
+    <nuclearcraft:voltaic_pile_basic>,
+    <nuclearcraft:voltaic_pile_du>,
+    <nuclearcraft:voltaic_pile_elite>,
+] as IItemStack[];
+
+for ncItem in ncItems {
+    furnace.remove(ncItem);
+    mods.jei.JEI.removeAndHide(ncItem);
+}
+
+// purge oxides
+val fissiles as int[][string] = {
+    "americium" :   [1,3,5,7,9,11],
+    "berkelium" :   [1,3,5,7],
+    "californium" : [1,3,5,7,9,11,13,15],
+    "curium" :      [1,3,5,7,9,11,13,15],
+    "neptunium" :   [1,3,5,7],
+    "plutonium" :   [1,3,5,7,9,11,13,15],
+    "thorium" :     [1,3,5,7],
+    "uranium" :     [1,3,5,7,9,11],
+} as int[][string];
+
+// oxides are odd-valued metadata values beginning with 1.
+//val metas as int[] = [1,3,5,7,9,11,13,15,17,19,21] as int[]; 
+for fissile,metas in fissiles {
+    for meta in metas {
+        val variants as string[] = [
+            "nuclearcraft:" + fissile,
+            "nuclearcraft:fuel_" + fissile,
+            "nuclearcraft:depleted_fuel_" + fissile,
+        ] as string[];
+
+        for variant in variants {
+            var oxide   = itemUtils.getItem(variant, meta);
+            var regular = itemUtils.getItem(variant, meta - 1);
+            if(!isNull(oxide)) {
+                furnace.remove(regular, oxide); // remove de-oxidation smelting
+                mods.jei.JEI.removeAndHide(oxide);
+            }
+        }
+    }
+}
+
+// Remove the fission recipes resulting in depleted oxide fuels
+val depletedFuels as int[][string] = {
+    "americium"   : [1,3],
+    "berkelium"   : [1,3],
+    "californium" : [1,3,5,7],
+    "curium"      : [1,3,5,7,9,11],
+    "neptunium"   : [1,3],
+    "plutonium"   : [1,3,5,7],
+    "thorium"     : [1,],
+    "uranium"     : [1,3,5,7],
+    "ic2"         : [0,1],
+    "mixed_oxide" : [0,1],
+} as int[][string];
+
+for depletedFuel,metas in depletedFuels {
+    for meta in metas {
+        var item = itemUtils.getItem("nuclearcraft:depleted_fuel_" + depletedFuel, meta);
+        if(!isNull(item)) {
+            mods.nuclearcraft.fission.removeRecipeWithOutput([item]);
+        }
+    }
+}
+
+// Get rid of unused NC fluids related to the MSR
+// unfortunately liquids aren't registered with their parent mod so this is ugly
+for liquid in game.liquids {
+    if(liquid.displayName has "Eutectic" |
+       liquid.displayName has "Molten Depleted" |
+       liquid.displayName has "Molten LE" |
+       liquid.displayName has "Molten HE" |
+       liquid.displayName has "Molten TB" |
+       liquid.displayName has "Fluoride" |
+       liquid.displayName has "FLiBe" |
+       liquid.name has "_23" | 
+       liquid.name has "_24" | 
+       liquid.name has "_25" ) {
+
+        purgeFluidFromJEI(liquid.name);
+
+        // Hide the fluid too
+        mods.jei.JEI.hide(liquid*1000);
+    }
+}
+
+// Unused NC fluid tile things to purge from JEI
+val ncFluids as string[] = [
+    "alugentum",
+    "alumina",
+    "aluminum",
+    "ammonia",
+    "arsenic",
+    "bas",
+    "bef2",
+    "beryllium",
+    "borax_solution",
+    "boric_acid",
+    "boron",
+    "boron10",
+    "boron11",
+    "boron_nitride_solution",
+    "calcium_sulfate_solution",
+    "carbon_dioxide",
+    "carbon_monoxide",
+    "chocolate_liquor",
+    "cocoa_butter",
+    "condensate_water",
+    "corium",
+    "dark_chocolate",
+    "deuterium",
+    "diborane",
+    "ethanol",
+    "ethene",
+    "exhaust_steam",
+    "ferroboron",
+    "flibe",
+    "fluorine",
+    "fluorite_water",
+    "fluoromethane",
+    "gelatin",
+    "hard_carbon",
+    "helium",
+    "helium3",
+    "high_pressure_steam",
+    "hydrated_gelatin",
+    "hydrofluoric_acid",
+    "hydrogen",
+    "koh",
+    "lif",
+    "liquidhelium",
+    "lithium",
+    "lithium6",
+    "lithium7",
+    "low_pressure_steam",
+    "low_quality_steam",
+    "manganese",
+    "manganese_dioxide",
+    "marshmallow",
+    "methanol",
+    "milk",
+    "milk_chocolate",
+    "nak",
+    "nak_hot",
+    "naoh",
+    "neutron",
+    "nitrogen",
+    "oxygen",
+    "oxygen_difluoride",
+    "plasma",
+    "potassium",
+    "potassium_fluoride_solution",
+    "potassium_hydroxide_solution",
+    "preheated_water",
+    "radaway",
+    "radaway_slow",
+    "sic_vapor",
+    "silver",
+    "sodium",
+    "sodium_fluoride_solution",
+    "sodium_hydroxide_solution",
+    "sugar",
+    "sulfur",
+    "sulfur_dioxide",
+    "sulfur_trioxide",
+    "sulfuric_acid",
+    "tough",
+    "tritium",
+    "unsweetened_chocolate"
+] as string[];
+
+for fluid in ncFluids {
+
+    // get rid of NC's weird fluid tile things
+    var item = itemUtils.getItem("nuclearcraft:fluid_" + fluid);
+    if(!isNull(item)) {
+        mods.jei.JEI.hide(item);
+    }
+
+    purgeFluidFromJEI(fluid);
+}
+
+// End of mass removals, now for replacements:
+
+recipes.remove(<nuclearcraft:compound:2>);
+mixer.recipeBuilder()
+    .outputs(<nuclearcraft:compound:2> * 2)
+    .inputs([<minecraft:redstone>, <minecraft:glowstone_dust>])
+    .duration(40).EUt(22).buildAndRegister();
 
 recipes.remove(<nuclearcraft:reactor_casing_transparent>);
-alloy.recipeBuilder().inputs([<nuclearcraft:fission_block>,<minecraft:glass>]).outputs([<nuclearcraft:reactor_casing_transparent>]).duration(50).EUt(16).buildAndRegister();
-recipes.remove(<nuclearcraft:part>);
-alloy.recipeBuilder().inputs([<ore:ingotFerroboron>,<ore:ingotLithium>]).outputs([<nuclearcraft:alloy:1>*2]).duration(300).EUt(16).buildAndRegister();
-alloy.recipeBuilder().inputs([<ore:dustFerroboron>,<ore:ingotLithium>]).outputs([<nuclearcraft:alloy:1>*2]).duration(300).EUt(16).buildAndRegister();
-alloy.recipeBuilder().inputs([<ore:ingotFerroboron>,<ore:dustLithium>]).outputs([<nuclearcraft:alloy:1>*2]).duration(300).EUt(16).buildAndRegister();
-alloy.recipeBuilder().inputs([<ore:dustFerroboron>,<ore:dustLithium>]).outputs([<nuclearcraft:alloy:1>*2]).duration(300).EUt(16).buildAndRegister();
-alloy.recipeBuilder().inputs([<ore:ingotSteel>,<ore:ingotBoron>]).outputs([<nuclearcraft:alloy:6>*2]).duration(300).EUt(16).buildAndRegister();
-alloy.recipeBuilder().inputs([<ore:dustSteel>,<ore:ingotBoron>]).outputs([<nuclearcraft:alloy:6>*2]).duration(300).EUt(16).buildAndRegister();
-alloy.recipeBuilder().inputs([<ore:ingotSteel>,<ore:dustBoron>]).outputs([<nuclearcraft:alloy:6>*2]).duration(300).EUt(16).buildAndRegister();
-alloy.recipeBuilder().inputs([<ore:dustSteel>,<ore:dustBoron>]).outputs([<nuclearcraft:alloy:6>*2]).duration(300).EUt(16).buildAndRegister();
-mixer.recipeBuilder().inputs([<gregtech:meta_item_1:2713> * 4,<gregtech:meta_item_1:2017> * 4,<thermalfoundation:material:1028>]).outputs(<gregtech:meta_item_1:2714> * 4).EUt(30).duration(400).buildAndRegister(); //Manyulyn
-mixer.recipeBuilder().inputs([<gregtech:meta_item_1:2232> * 3,<minecraft:blaze_powder>]).outputs(<gregtech:meta_item_1:2713> * 4).EUt(30).duration(200).buildAndRegister();	//Ardite
-mixer.recipeBuilder().inputs([<thermalfoundation:material:1028>,<gregtech:meta_item_1:2072>]).outputs(<thermalfoundation:material:72> * 2).EUt(30).duration(200).buildAndRegister();	//Mana Infused
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:reactor_casing_transparent>])
+    .inputs([<nuclearcraft:fission_block>, <minecraft:glass>])
+    .duration(50).EUt(16).buildAndRegister();
 
-	
+// permutations of ferroboron and lithium ingots/dusts
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:1> * 2])
+    .inputs([<ore:ingotFerroboron>, <ore:ingotLithium>])
+    .duration(300).EUt(16).buildAndRegister();
 
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustRedstone>*16]).outputs([<nuclearcraft:cooler:2>]).duration(400).EUt(2).buildAndRegister();
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustNetherQuartz>*16]).outputs([<nuclearcraft:cooler:3>]).duration(400).EUt(2).buildAndRegister();
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustGold>*16]).outputs([<nuclearcraft:cooler:4>]).duration(400).EUt(2).buildAndRegister();
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustGlowstone>*16]).outputs([<nuclearcraft:cooler:5>]).duration(400).EUt(2).buildAndRegister();
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustLapis>*16]).outputs([<nuclearcraft:cooler:6>]).duration(400).EUt(2).buildAndRegister();
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustDiamond>*16]).outputs([<nuclearcraft:cooler:7>]).duration(400).EUt(2).buildAndRegister();
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustEnderium>*16]).outputs([<nuclearcraft:cooler:9>]).duration(400).EUt(9).buildAndRegister();
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustIron>*16]).outputs([<nuclearcraft:cooler:11>]).duration(400).EUt(2).buildAndRegister();
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustEmerald>*16]).outputs([<nuclearcraft:cooler:12>]).duration(400).EUt(2).buildAndRegister();
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustCopper>*16]).outputs([<nuclearcraft:cooler:13>]).duration(400).EUt(2).buildAndRegister();
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustTin>*16]).outputs([<nuclearcraft:cooler:14>]).duration(400).EUt(2).buildAndRegister();
-canner.recipeBuilder().inputs([<nuclearcraft:cooler>,<ore:dustMagnesium>*16]).outputs([<nuclearcraft:cooler:15>]).duration(400).EUt(2).buildAndRegister();
-fluid_canner.recipeBuilder().inputs([<nuclearcraft:cooler>]).fluidInputs([<liquid:water>*1000]).outputs([<nuclearcraft:cooler:1>]).duration(400).EUt(2).buildAndRegister();
-fluid_canner.recipeBuilder().inputs([<nuclearcraft:cooler>]).fluidInputs([<liquid:helium>*1000]).outputs([<nuclearcraft:cooler:8>]).duration(400).EUt(2).buildAndRegister();
-fluid_canner.recipeBuilder().inputs([<nuclearcraft:cooler>]).fluidInputs([<liquid:cryotheum>*1000]).outputs([<nuclearcraft:cooler:10>]).duration(400).EUt(2).buildAndRegister();
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:1> * 2])
+    .inputs([<ore:dustFerroboron>, <ore:ingotLithium>])
+    .duration(300).EUt(16).buildAndRegister();
+
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:1> * 2])
+    .inputs([<ore:ingotFerroboron>, <ore:dustLithium>])
+    .duration(300).EUt(16).buildAndRegister();
+
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:1> * 2])
+    .inputs([<ore:dustFerroboron>, <ore:dustLithium>])
+    .duration(300).EUt(16).buildAndRegister();
+
+// permutations of steel and boron ingots/dusts
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:6> * 2])
+    .inputs([<ore:ingotSteel>, <ore:ingotBoron>])
+    .duration(300).EUt(16).buildAndRegister();
+
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:6> * 2])
+    .inputs([<ore:dustSteel>, <ore:ingotBoron>])
+    .duration(300).EUt(16).buildAndRegister();
+
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:6> * 2])
+    .inputs([<ore:ingotSteel>, <ore:dustBoron>])
+    .duration(300).EUt(16).buildAndRegister();
+
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:6> * 2])
+    .inputs([<ore:dustSteel>, <ore:dustBoron>])
+    .duration(300).EUt(16).buildAndRegister();
+
+// FIXME: this stuff isn't really related to NC at all
+//Manyullyn
+mixer.recipeBuilder()
+    .outputs(<gregtech:meta_item_1:2714> * 4)
+    .inputs([<gregtech:meta_item_1:2713> * 4, <gregtech:meta_item_1:2017> * 4, <thermalfoundation:material:1028>])
+    .duration(400).EUt(30).buildAndRegister();
+
+//Ardite
+mixer.recipeBuilder()
+    .outputs(<gregtech:meta_item_1:2713> * 4)
+    .inputs([<gregtech:meta_item_1:2232> * 3, <minecraft:blaze_powder>])
+    .duration(200).EUt(30).buildAndRegister();
+
+// Remove recipes for items with a specific range of metadata values
+function delRange(name as string, start as int, stop as int) {
+    for i in start to stop+1 { // endval is exclusive
+        var item = itemUtils.getItem(name);
+        if(!isNull(item)) {
+            recipes.remove(item);
+        }
+    }
+}
+
+// remove table recipes for coolers and replace with canning machine recipes
+delRange("nuclearcraft:cooler",1,15);
 
 recipes.remove(<nuclearcraft:cooler:1>);
+fluid_canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:1>])
+    .inputs([<nuclearcraft:cooler>])
+    .fluidInputs([<liquid:water> * 1000])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:2>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:2>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustRedstone> * 16])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:3>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:3>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustNetherQuartz> * 16])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:4>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:4>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustGold> * 16])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:5>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:5>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustGlowstone> * 16])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:6>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:6>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustLapis> * 16])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:7>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:7>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustDiamond> * 16])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:8>);
+fluid_canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:8>])
+    .inputs([<nuclearcraft:cooler>])
+    .fluidInputs([<liquid:helium> * 1000])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:9>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:9>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustEnderium> * 16])
+    .duration(400).EUt(9).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:10>);
+fluid_canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:10>])
+    .inputs([<nuclearcraft:cooler>])
+    .fluidInputs([<liquid:cryotheum> * 1000])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:11>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:11>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustIron> * 16])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:12>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:12>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustEmerald> * 16])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:13>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:13>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustCopper> * 16])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:14>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:14>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustTin> * 16])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cooler:15>);
-recipes.remove(<nuclearcraft:part:1>);
-recipes.remove(<nuclearcraft:part:2>);
-recipes.remove(<nuclearcraft:part:3>);
+canner.recipeBuilder()
+    .outputs([<nuclearcraft:cooler:15>])
+    .inputs([<nuclearcraft:cooler>, <ore:dustMagnesium> * 16])
+    .duration(400).EUt(2).buildAndRegister();
+
 recipes.remove(<nuclearcraft:cobblestone_generator>);
+makeShaped("of_nc_cobblestone_generator",
+    <nuclearcraft:cobblestone_generator>,
+    ["AAA",
+     "B C",
+     "AAA"],
+    { A : <ore:plateSteel>,
+      B : <minecraft:water_bucket:*>,
+      C : <minecraft:lava_bucket:*> });
+
+makeShaped("of_nc_cobblestone_generator_mirrored",
+    <nuclearcraft:cobblestone_generator>,
+    ["AAA",
+     "C B",
+     "AAA"],
+    { A : <ore:plateSteel>,
+      B : <minecraft:water_bucket:*>,
+      C : <minecraft:lava_bucket:*> });
+
 recipes.remove(<nuclearcraft:water_source>);
-recipes.remove(<nuclearcraft:fission_controller_new_fixed>);
-recipes.remove(<nuclearcraft:fission_block>);
-recipes.remove(<nuclearcraft:fission_block:1>);
-recipes.remove(<nuclearcraft:cell_block>);
-
-
-recipes.addShaped(<nuclearcraft:cobblestone_generator>, [[<gregtech:meta_item_1:12184>,<gregtech:meta_item_1:12184>,<gregtech:meta_item_1:12184>], [<minecraft:water_bucket:*>, null, <minecraft:lava_bucket:*>], [<gregtech:meta_item_1:12184>,<gregtech:meta_item_1:12184>,<gregtech:meta_item_1:12184>]]);
-recipes.addShaped(<nuclearcraft:cobblestone_generator>, [[<gregtech:meta_item_1:12184>,<gregtech:meta_item_1:12184>,<gregtech:meta_item_1:12184>], [<minecraft:lava_bucket:*>, null, <minecraft:water_bucket:*>], [<gregtech:meta_item_1:12184>,<gregtech:meta_item_1:12184>,<gregtech:meta_item_1:12184>]]);
-recipes.addShaped(<nuclearcraft:water_source>, [
-	[<ore:plateWroughtIron>,<ore:plateWroughtIron>,<ore:plateWroughtIron>], 
-	[<minecraft:water_bucket:*>, null, <minecraft:water_bucket:*>], 
-	[<ore:plateWroughtIron>,<ore:plateWroughtIron>,<ore:plateWroughtIron>]]);
+makeShaped("of_nc_water_source", <nuclearcraft:water_source>,
+    ["AAA",
+     "B B",
+     "AAA"],
+    { A : <ore:plateWroughtIron>,
+      B : <minecraft:water_bucket:*> });
 
 //Uranium RTG
 recipes.remove(<nuclearcraft:rtg_uranium>);
-recipes.addShaped(<nuclearcraft:rtg_uranium>, [[<ore:plateBasic>, <ore:ingotGraphite>, <ore:plateBasic>], [<ore:ingotGraphite>, <gregtech:compressed_3:12>, <ore:ingotGraphite>], [<ore:plateBasic>, <ore:ingotGraphite>, <ore:plateBasic>]]);
-	
-	
-//Basic Plating
-recipes.addShaped(<nuclearcraft:part> * 2, [
-	[<ore:ingotTough>,<ore:plateTungsten>,<ore:ingotTough>],
-	[<ore:plateTungsten>,<contenttweaker:steelplating>,<ore:plateTungsten>],
-	[<ore:ingotTough>,<ore:plateTungsten>,<ore:ingotTough>]]);	
-	
-//Advanced Plating
-recipes.addShaped(<nuclearcraft:part:1> * 2, [
-	[<ore:ingotHardCarbon>,<ore:plateYttriumBariumCuprate>,<ore:ingotHardCarbon>],
-	[<ore:plateYttriumBariumCuprate>,<nuclearcraft:part>,<ore:plateYttriumBariumCuprate>],
-	[<ore:ingotHardCarbon>,<ore:plateYttriumBariumCuprate>,<ore:ingotHardCarbon>]]);
-	
-recipes.addShaped(<nuclearcraft:part:3>, [
-	[<nuclearcraft:gem_dust:1>,<ore:plateEnderium>,<nuclearcraft:gem_dust:1>],
-	[<ore:plateEnderium>,<nuclearcraft:part:2>,<ore:plateEnderium>],
-	[<nuclearcraft:gem_dust:1>,<ore:plateEnderium>,<nuclearcraft:gem_dust:1>]]);
+makeShaped("of_nc_rtg_uranium", <nuclearcraft:rtg_uranium>,
+    ["ABA",
+     "BCB",
+     "ABA"],
+    { A : <ore:plateBasic>,
+      B : <ore:ingotGraphite>,
+      C : <gregtech:compressed_3:12> });
 
-recipes.addShaped(<nuclearcraft:fission_block> * 8, [
-	[<nuclearcraft:part>,<nuclearcraft:part>,<nuclearcraft:part>],
-	[<nuclearcraft:part>,<gregtech:metal_casing:7>,<nuclearcraft:part>],
-	[<nuclearcraft:part>,<nuclearcraft:part>,<nuclearcraft:part>]]);		
-	
-recipes.addShaped(<nuclearcraft:fission_controller_new_fixed>	, [
-	[<nuclearcraft:part:1>,<ore:circuitExtreme>,<nuclearcraft:part:1>],
-	[<ore:circuitExtreme>,<gregtech:metal_casing:7>,<ore:circuitExtreme>],
-	[<nuclearcraft:part:1>,<ore:circuitExtreme>,<nuclearcraft:part:1>]]);		
-	
-alloy.recipeBuilder().inputs([<ore:gemDiamond>,<ore:ingotGraphite> * 2]).outputs([<nuclearcraft:alloy:2> * 2]).duration(300).EUt(500).buildAndRegister();
-alloy.recipeBuilder().inputs([<nuclearcraft:part:1>,<contenttweaker:stabilizeduranium>]).outputs([<nuclearcraft:part:2> * 2]).duration(400).EUt(2000).buildAndRegister();
-alloy.recipeBuilder().inputs([<nuclearcraft:alloy:2>,<ore:ingotTough>]).outputs([<nuclearcraft:alloy:10>]).duration(200).EUt(1000).buildAndRegister();
-alloy.recipeBuilder().inputs([<gregtech:meta_item_1:10038>,<gregtech:meta_item_1:2009> * 2]).outputs([<nuclearcraft:alloy:3> * 3]).duration(100).EUt(200).buildAndRegister();
-alloy.recipeBuilder().inputs([<gregtech:meta_item_1:10207>,<thermalfoundation:material:167>]).outputs([<nuclearcraft:alloy:11> * 2]).duration(100).EUt(200).buildAndRegister();
-alloy.recipeBuilder().inputs([<thermalfoundation:material:166>,<nuclearcraft:ingot:10>]).outputs([<nuclearcraft:alloy:12> * 2]).duration(100).EUt(200).buildAndRegister();
-reactor.recipeBuilder().inputs([<ore:orePyrolusite> * 6]).fluidInputs([<liquid:sulfuric_acid> * 3000]).outputs(<nuclearcraft:gem_dust:1>).fluidOutputs([<liquid:manganese> * 4320]).EUt(2000).duration(200).buildAndRegister();
-reactor.recipeBuilder().inputs([<ore:oreRedstone> * 12]).fluidInputs([<liquid:sulfuric_acid> * 6000]).outputs(<nuclearcraft:gem_dust:1>).fluidOutputs([<liquid:redstone> * 19008]).EUt(2000).duration(200).buildAndRegister();
-reactor.recipeBuilder().inputs([<contenttweaker:t2laser>]).fluidInputs([<liquid:radon> * 1000]).outputs(<contenttweaker:t3laser>).EUt(2000).duration(200).buildAndRegister();
+// Basic Plating
+recipes.remove(<nuclearcraft:part>);
+makeShaped("of_nc_basic_plating", <nuclearcraft:part> * 2,
+    ["ABA",
+     "BCB",
+     "ABA"],
+    { A : <ore:ingotTough>,
+      B : <ore:plateTungsten>,
+      C : <contenttweaker:steelplating> });
+
+// Advanced Plating
+recipes.remove(<nuclearcraft:part:1>);
+makeShaped("of_nc_advanced_plating", <nuclearcraft:part:1> * 2,
+    ["ABA",
+     "BCB",
+     "ABA"],
+    { A : <ore:ingotHardCarbon>,
+      B : <ore:plateYttriumBariumCuprate>,
+      C : <nuclearcraft:part> });
+
+// DU Plating
+recipes.remove(<nuclearcraft:part:2>);
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:part:2> * 2])
+    .inputs([<nuclearcraft:part:1>, <contenttweaker:stabilizeduranium>])
+    .duration(400).EUt(2000).buildAndRegister();
+
+// Elite Plating
+recipes.remove(<nuclearcraft:part:3>);
+makeShaped("of_nc_elite_plating", <nuclearcraft:part:3>,
+    ["ABA",
+     "BCB",
+     "ABA"],
+    { A : <nuclearcraft:gem_dust:1>,
+      B : <ore:plateEnderium>,
+      C : <nuclearcraft:part:2> });
+
+// unused items
+recipes.remove(<nuclearcraft:fission_block:1>);
+recipes.remove(<nuclearcraft:cell_block>);
+
+recipes.remove(<nuclearcraft:fission_block>);
+makeShaped("of_nc_fission_block", <nuclearcraft:fission_block> * 8,
+    ["AAA",
+     "ABA",
+     "AAA"],
+    { A : <nuclearcraft:part>,
+      B : <gregtech:metal_casing:7> });
+
+recipes.remove(<nuclearcraft:fission_controller_new_fixed>);
+makeShaped("of_nc_fission_controller", <nuclearcraft:fission_controller_new_fixed>,
+    ["ABA",
+     "BCB",
+     "ABA"],
+    { A : <nuclearcraft:part:1>,
+      B : <ore:circuitExtreme>,
+      C : <gregtech:metal_casing:7> });
+
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:2> * 2])
+    .inputs([<ore:gemDiamond>, <ore:ingotGraphite> * 2])
+    .duration(300).EUt(500).buildAndRegister();
+
+// Extreme Alloy - unused
+/*
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:10>])
+    .inputs([<nuclearcraft:alloy:2>, <ore:ingotTough>])
+    .duration(200).EUt(1000).buildAndRegister();
+*/
+
+// magnesium diboride - unused
+/*
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:3> * 3])
+    .inputs([<gregtech:meta_item_1:10038>, <gregtech:meta_item_1:2009> * 2])
+    .duration(100).EUt(200).buildAndRegister();
+*/
+
+// Thermoconducting Alloy - Unused
+/*
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:11> * 2])
+    .inputs([<gregtech:meta_item_1:10207>, <thermalfoundation:material:167>])
+    .duration(100).EUt(200).buildAndRegister();
+*/
+
+// zircaloy - unused
+/*
+alloy.recipeBuilder()
+    .outputs([<nuclearcraft:alloy:12> * 2])
+    .inputs([<thermalfoundation:material:166>, <nuclearcraft:ingot:10>])
+    .duration(100).EUt(200).buildAndRegister();
+*/
+
+reactor.recipeBuilder()
+    .outputs(<nuclearcraft:gem_dust:1>)
+    .inputs([<ore:orePyrolusite> * 6])
+    .fluidInputs([<liquid:sulfuric_acid> * 3000])
+    .fluidOutputs([<liquid:manganese> * 4320])
+    .duration(200).EUt(2000).buildAndRegister();
+
+reactor.recipeBuilder()
+    .outputs(<nuclearcraft:gem_dust:1>)
+    .inputs([<ore:oreRedstone> * 12])
+    .fluidInputs([<liquid:sulfuric_acid> * 6000])
+    .fluidOutputs([<liquid:redstone> * 19008])
+    .duration(200).EUt(2000).buildAndRegister();
+
+reactor.recipeBuilder().inputs([<contenttweaker:t2laser>])
+    .outputs(<contenttweaker:t3laser>)
+    .fluidInputs([<liquid:radon> * 1000])
+    .duration(200).EUt(2000).buildAndRegister();
 
 recipes.remove(<nuclearcraft:fission_port>);
+recipes.addShapeless("of_nc_fission_port", <nuclearcraft:fission_port>,
+    [<nuclearcraft:fission_block>, <minecraft:hopper>]);
+
 recipes.remove(<nuclearcraft:part:4>);
+makeShaped("of_nc_coppersolenoid", <nuclearcraft:part:4>,
+    ["AAA",
+     "ABA",
+     "AAA"],
+    { A : <ore:wireFineCopper>,
+      B : <ore:stickStainlessSteel> });
+
+
+// unused part
 recipes.remove(<nuclearcraft:part:5>);
-recipes.addShapeless(<nuclearcraft:fission_port>, [
-	<nuclearcraft:fission_block>,<minecraft:hopper>]);
+/*
+makeShaped("of_nc_magnesium_diboride_solenoid", <nuclearcraft:part:5>,
+    ["AAA",
+     "ABA",
+     "AAA"],
+    { A : <ore:wireFineTungsten>,
+      B : <ore:ingotMagnesiumDiboride> });
+*/
 
-recipes.addShaped(<nuclearcraft:part:4>, [
-	[<ore:wireFineCopper>, <ore:wireFineCopper>, <ore:wireFineCopper>], 
-	[<ore:wireFineCopper>, <gregtech:meta_item_1:14183>, <ore:wireFineCopper>], 
-	[<ore:wireFineCopper>, <ore:wireFineCopper>, <ore:wireFineCopper>]]);
+// Uranium 235 - from dust
+thermal_sep.recipeBuilder()
+    .outputs(<nuclearcraft:uranium:4>)
+    .inputs([<gregtech:meta_item_1:2076>])
+    .duration(3200).EUt(48).buildAndRegister();
 
-recipes.addShaped(<nuclearcraft:part:5>, [
-	[<ore:wireFineTungsten>, <ore:wireFineTungsten>, <ore:wireFineTungsten>], 
-	[<ore:wireFineTungsten>, <nuclearcraft:alloy:3>, <ore:wireFineTungsten>], 
-	[<ore:wireFineTungsten>, <ore:wireFineTungsten>, <ore:wireFineTungsten>]]);
-
-thermal_sep.recipeBuilder().inputs([<gregtech:meta_item_1:2076>]).outputs(<nuclearcraft:uranium:4>).EUt(48).duration(3200).buildAndRegister();
-thermal_sep.recipeBuilder().inputs([<gregtech:meta_item_1:10076>]).outputs(<nuclearcraft:uranium:4>).EUt(48).duration(3200).buildAndRegister();
-
-
-
-
-
-
-
+// Uranium 235 - from ingot
+thermal_sep.recipeBuilder()
+    .outputs(<nuclearcraft:uranium:4>)
+    .inputs([<gregtech:meta_item_1:10076>])
+    .duration(3200).EUt(48).buildAndRegister();
 

--- a/overrides/scripts/Nuclearcraft.zs
+++ b/overrides/scripts/Nuclearcraft.zs
@@ -37,7 +37,8 @@ mods.nuclearcraft.decay_generator.removeAllRecipes();
 mods.nuclearcraft.fusion.removeAllRecipes();
 mods.nuclearcraft.salt_fission.removeAllRecipes();
 mods.nuclearcraft.heat_exchanger.removeAllRecipes();
-//mods.nuclearcraft.steam_turbine.removeAllRecipes(); FIXME: probably in a newer version?
+//FIXME: NC lists this next one in its docs but CT doesn't like it. Disabling for now.
+//mods.nuclearcraft.steam_turbine.removeAllRecipes();
 mods.nuclearcraft.condenser.removeAllRecipes();
 
 // Hide NC categories related to MSR and Turbines
@@ -236,7 +237,7 @@ val removals as Removal[] = [
     Removal(<nuclearcraft:voltaic_pile_basic>),
     Removal(<nuclearcraft:voltaic_pile_du>),
     Removal(<nuclearcraft:voltaic_pile_elite>),
-] as Removal[];
+] as Removal[];      
 
 for removal in removals {
     if(removal.hasFurnace) {
@@ -263,28 +264,16 @@ zenClass Material {
         this.depletedFuelMetas = depletedFuelMetas;
     }
 
-    function fissileName() as string {
-        return "nuclearcraft:" + this.name;
-    }
-
-    function fuelName() as string {
-        return "nuclearcraft:fuel_" + this.name;
-    }
-
-    function depletedFuelName() as string {
-        return "nuclearcraft:depleted_fuel_" + this.name;
-    }
-
     function fissileItem(meta as int) as IItemStack {
-        return itemUtils.getItem(this.fissileName(), meta);
+        return itemUtils.getItem("nuclearcraft:" + this.name, meta);
     }
 
     function fuelItem(meta as int) as IItemStack {
-        return itemUtils.getItem(this.fuelName(), meta);
+        return itemUtils.getItem("nuclearcraft:fuel_" + this.name, meta);
     }
 
     function depletedFuelItem(meta as int) as IItemStack {
-        return itemUtils.getItem(this.depletedFuelName(), meta);
+        return itemUtils.getItem("nuclearcraft:depleted_fuel_" + this.name, meta);
     }
 
 }

--- a/overrides/scripts/Nuclearcraft.zs
+++ b/overrides/scripts/Nuclearcraft.zs
@@ -183,7 +183,6 @@ val ncItems as IItemStack[] = [
     <nuclearcraft:roasted_cocoa_beans>,
     <nuclearcraft:salt_fission_beam>,
     <nuclearcraft:salt_fission_computer_port>,
-    <nuclearcraft:salt_fission_controller>,
     <nuclearcraft:salt_fission_distributor>,
     <nuclearcraft:salt_fission_frame>,
     <nuclearcraft:salt_fission_glass>,
@@ -680,13 +679,11 @@ alloy.recipeBuilder()
     .inputs([<ore:gemDiamond>, <ore:ingotGraphite> * 2])
     .duration(300).EUt(500).buildAndRegister();
 
-// Extreme Alloy - unused
-/*
+// Extreme Alloy
 alloy.recipeBuilder()
     .outputs([<nuclearcraft:alloy:10>])
     .inputs([<nuclearcraft:alloy:2>, <ore:ingotTough>])
     .duration(200).EUt(1000).buildAndRegister();
-*/
 
 // magnesium diboride - unused
 /*

--- a/overrides/scripts/ThermalExpansion.zs
+++ b/overrides/scripts/ThermalExpansion.zs
@@ -448,3 +448,9 @@ furnace.addRecipe(<thermalfoundation:material:165>, <gregtech:meta_item_1:2707>)
 //Lumium
 furnace.remove(<gregtech:meta_item_1:10706>, <gregtech:meta_item_1:2706>);
 furnace.addRecipe(<thermalfoundation:material:166>, <gregtech:meta_item_1:2706>);
+
+//Mana Infused
+mixer.recipeBuilder()
+    .outputs(<thermalfoundation:material:72> * 2)
+    .inputs([<thermalfoundation:material:1028>, <gregtech:meta_item_1:2072>])
+    .duration(200).EUt(30).buildAndRegister();

--- a/overrides/scripts/_oreDict.zs
+++ b/overrides/scripts/_oreDict.zs
@@ -541,7 +541,12 @@ var ingotsDisabled as IItemStack[][IOreDictEntry] = {
 		<libvulpes:productingot:6>,
 		<thermalfoundation:material:160>,
 		<nuclearcraft:alloy:5>
-	]
+	],
+
+    #ingotUranium235
+    <ore:ingotUranium235> : [
+        <gregtech:meta_item_1:10076>,
+    ],
 
 };
 
@@ -1517,57 +1522,6 @@ mods.jei.JEI.removeAndHide(<morefurnaces:furnaceblock:4>);
 mods.jei.JEI.removeAndHide(<moreplates:hammer>);
 
 
-//Nuclearcraft Removals
-mods.jei.JEI.removeAndHide(<nuclearcraft:lithium_ion_cell>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:portable_ender_chest>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:solar_panel_basic>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:solar_panel_advanced>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:solar_panel_du>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:solar_panel_elite>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:decay_generator>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:voltaic_pile_basic>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:voltaic_pile_advanced>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:voltaic_pile_du>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:voltaic_pile_elite>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:lithium_ion_battery_basic>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:lithium_ion_battery_advanced>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:lithium_ion_battery_du>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:lithium_ion_battery_elite>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:ingot_oxide>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:ingot_oxide:1>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:ingot_oxide:2>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:ingot_oxide:3>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:dust_oxide>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:dust_oxide:1>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:dust_oxide:2>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:dust_oxide:3>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:alloy:4>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:alloy:13>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:compound:8>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:gem_dust:11>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:compound:5>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:alloy:7>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:alloy:8>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:alloy:9>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:compound:3>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:alloy:14>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:turbine_rotor_blade_sic_sic_cmc>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:compound:4>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:compound:6>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:compound:7>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:compound:9>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:part:13>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:gem_dust:5>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:block_depleted_thorium>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:block_depleted_uranium>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:gem_dust:6>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:gem_dust:10>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:uranium:9>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:uranium:5>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:upgrade>);
-
-<ore:ingotUranium235>.remove(<gregtech:meta_item_1:10076>);
-
 //Standard Expansion Removals
 mods.jei.JEI.removeAndHide(<bq_standard:loot_chest>);
 mods.jei.JEI.removeAndHide(<bq_standard:loot_chest:25>);
@@ -1636,7 +1590,6 @@ mods.jei.JEI.removeAndHide(<libvulpes:battery>);
 mods.jei.JEI.removeAndHide(<libvulpes:battery:1>);
 mods.jei.JEI.removeAndHide(<libvulpes:productfan:6>);
 mods.jei.JEI.removeAndHide(<appliedenergistics2:material:5>);
-mods.jei.JEI.removeAndHide(<nuclearcraft:gem:6>);
 
 //Lumberaxe Removal
 mods.jei.JEI.removeAndHide(<lumberjack:infinity_lumberaxe>);


### PR DESCRIPTION
Fixes #404 but also scope crept into an overhaul of cleanup for NuclearCraft.

Removing dead-end paths in crafting, clearing out unusable machinery/items/recipes from the registry and JEI, and reorganizing some of the script file structure to better handle the same.